### PR TITLE
汉化 阿尔玟 加冕庆典选择人类身份表露与阿拉贡白头偕老的喜悦 Arwen End Celebration.json

### DIFF
--- a/clones/1/Arwen End Celebration.json
+++ b/clones/1/Arwen End Celebration.json
@@ -107,17 +107,17 @@
     "NpcInteractLines": {
         "Lines": [
             {
-                "Line": "I am finally reunited with my Aragorn!",
+                "Line": "终于我和阿拉贡团聚了！",
                 "Song": "",
                 "Slot": 0
             },
             {
-                "Line": "Giving up immortality was a good decision!",
+                "Line": "我选择了凡人的命运。",
                 "Song": "",
                 "Slot": 1
             },
             {
-                "Line": "In the end everything went well!",
+                "Line": "四方太平，尘埃落定。",
                 "Song": "",
                 "Slot": 2
             }


### PR DESCRIPTION
场景是阿拉贡加冕，阿拉贡与阿尔玟成婚。确实可以表达喜悦之情。但阿尔玟选择放弃永生绝不是什么good decision，她做出这个选择经历了心理的挣扎，并且她明确之后将经历凡人的离别之苦（电影剧情）。英文原句给我美式英雄的女伴这样俗套设定的感觉，所以她如何看待放弃永生我用了较为平和的语气。第三句直译就是表达美好大团圆结局的喜悦。阿尔玟的形象偏内敛端庄，也做平和语气的修改。